### PR TITLE
Feat: Teste favorite_icon_renderizando

### DIFF
--- a/app_movies/lib/pages/favorite/favorite_screen.dart
+++ b/app_movies/lib/pages/favorite/favorite_screen.dart
@@ -97,7 +97,30 @@ class _FavoriteScreenState extends State<FavoriteScreen>
                             color: Colors.red,
                           ),
                           onPressed: () {
-                            favoritesProvider.toggleFavorite(movie);
+                            showDialog(
+                              context: context,
+                              builder: (BuildContext context) {
+                                return AlertDialog(
+                                  title: const Text('Confirmação'),
+                                  content: const Text('Remover filme dos favoritos?'),
+                                  actions: <Widget>[
+                                    TextButton(
+                                      child: const Text('Não'),
+                                      onPressed: () {
+                                        Navigator.of(context).pop();
+                                      },
+                                    ),
+                                    TextButton(
+                                      child: const Text('Sim'),
+                                      onPressed: () {
+                                        favoritesProvider.toggleFavorite(movie);
+                                        Navigator.of(context).pop();
+                                      },
+                                    ),
+                                  ],
+                                );
+                              },
+                            );
                           },
                         ),
                       ],

--- a/app_movies/test/pages/favorite/favorite_icon_state_test.dart
+++ b/app_movies/test/pages/favorite/favorite_icon_state_test.dart
@@ -1,0 +1,42 @@
+import 'package:app_movies/models/movie.dart';
+import 'package:app_movies/pages/favorite/favorite_icon_state.dart';
+import 'package:app_movies/pages/favorite/favorites_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+void main() {
+  group('FavoriteIconButton', () {
+    testWidgets('deve renderizar corretamente', (tester) async {
+      final movie = Movie(
+        id: '1',
+        title: 'Teste Mateus',
+        originalTitle: 'Original Title',
+        originalTitleRomanised: 'Original Title Romanised',
+        image: 'image.jpg',
+        movieBanner: 'banner.jpg',
+        description: 'Movie Description',
+        director: 'Movie Director',
+        producer: 'Movie Producer',
+        releaseDate: '2022-01-01',
+        runningTime: '120 min',
+        rtScore: '90',
+        people: [],
+        species: [],
+        locations: [],
+        vehicles: [],
+        url: 'https://guibliapi.herokuapp.com/films/1',
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ChangeNotifierProvider<FavoritesProvider>(
+            create: (_) => FavoritesProvider(),
+            child: FavoriteIconButton(movie: movie),
+          ),
+        ),
+      );
+
+      expect(find.byType(FavoriteIconButton), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Teste do Favorite Icon. Foi testado se o icone de favorito é renderizado na tela. 
Também foi colocado um modal pra confirmar a retirada de filmes do favoritos. 
![image](https://github.com/MateusOliveira991/koru_modulo4_app_flutter/assets/142065746/a56d55b9-9c3d-42c9-bcba-5edda27ec74e)

![image](https://github.com/MateusOliveira991/koru_modulo4_app_flutter/assets/142065746/4db51507-5e62-4065-9905-38aa9448d348)


